### PR TITLE
Unify 'a tree and 'a nesting 

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -6,7 +6,7 @@ open Tree
 open Nesting
 open Cmplx
    
-let test = Lf ;;   
+let test = Lf () ;;   
 
 let () = Printf.printf "Hello, world!\n";;
 

--- a/src/tree.ml
+++ b/src/tree.ml
@@ -145,6 +145,9 @@ module TraverseImpl (A : Applicative) : LocalBase
        with type 'a td = 'a tree_deriv = 
 struct
 
+  (* XXX: after generalizing [LocalBase], one could write a generic
+  traverse for [gtree] and, therefore [tree] and [nesting] *)
+
   open A
 
   type 'a t = 'a tree
@@ -192,7 +195,10 @@ module TreeMatchImpl (M : MonadError with type e = string)
        with type 'a m = 'a M.m
        with type ta = addr
        with type 'a td = 'a tree_deriv = struct
-                   
+
+  (* XXX: after generalizing [MatchBase], one could write a generic
+  traverse for [gtree] and, therefore [tree] and [nesting] *)
+
   open M
                                   
   type 'a t = 'a tree
@@ -237,14 +243,14 @@ module TreeOps (M: MonadError with type e = string) = struct
 
   module TM = TreeMatch(M)
      
-  let as_leaf : 'a tree -> unit m =
+  let as_leaf : 'a 'b. ('a, 'b) gtree -> 'b m =
     function
-      Lf () -> return ()
+      Lf a -> return a
     | Nd (_, _) -> throw "Leaf force failed"
 
-  let as_node : 'a tree -> ('a * 'a tree_shell) m =
+  let as_node : 'a 'b. ('a, 'b) gtree -> ('a * ('a, 'b) gtree_shell) m =
     function
-      Lf () -> throw "Node force failed"
+      Lf _ -> throw "Node force failed"
     | Nd (a, sh) -> return (a, sh)
 
   let root_value : 'a tree -> 'a m =


### PR DESCRIPTION
Following the Grand Scheme described on the whiteboard, I've unified both definitions of 'a tree and 'a nesting with a type ('a, 'b) gtree. As a result, I've defined polymorphic operations working on both types (thus removing some code duplication). I'm fairly confident that I haven't changed the semantics of the operations but, lacking unit tests, one cannot be too sure :)

I do *not* recommend including these changes in your master tree as-is since the generic operations are less informative (you had distinct messages for trees and nestings). This is merely a proof-of-concept.